### PR TITLE
Pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
-    "@reststate/client": "^0.0.3"
+    "@reststate/client": "^0.0.4"
   },
   "peerDependencies": {
     "vuex": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",


### PR DESCRIPTION
Adds experimental actions and getters for working with pagination:

```
store.dispatch('yourResource/loadPage', {
  options: {
    'page[number]': 1,
    'page[size]': 10,
  }
});
```

After calling the `loadPage` action, the following getters will be available:

- `page`: the last-returned page of records
- `hasNext`: whether there is a "next" page
- `hasPrevious`: whether there is a "previous" page

As well as the following actions:

- `loadNextPage`: loads the next page of records, as returned in the `link.next` in the response data.
- `loadPreviousPage`: same, but for previous page