### PR TITLE
Meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -36,6 +36,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       status: STATUS_INITIAL,
       links: {},
       lastCreated: null,
+      lastMeta: null,
     },
 
     mutations: {
@@ -65,6 +66,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
 
       STORE_PAGE: (state, records) => {
         state.page = records.map(({ id }) => id);
+      },
+
+      STORE_META: (state, meta) => {
+        state.lastMeta = meta;
       },
 
       STORE_RELATED: (state, parent) => {
@@ -103,6 +108,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           .then(result => {
             commit('SET_STATUS', STATUS_SUCCESS);
             commit('REPLACE_ALL_RECORDS', result.data);
+            commit('STORE_META', result.meta);
           })
           .catch(handleError(commit));
       },
@@ -114,6 +120,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           .then(results => {
             commit('SET_STATUS', STATUS_SUCCESS);
             commit('STORE_RECORD', results.data);
+            commit('STORE_META', results.meta);
           })
           .catch(handleError(commit));
       },
@@ -127,6 +134,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
             const matches = results.data;
             commit('STORE_RECORDS', matches);
             commit('STORE_FILTERED', { filter, matches });
+            commit('STORE_META', results.meta);
           })
           .catch(handleError(commit));
       },
@@ -139,6 +147,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
             commit('SET_STATUS', STATUS_SUCCESS);
             commit('STORE_RECORDS', response.data);
             commit('STORE_PAGE', response.data);
+            commit('STORE_META', response.meta);
             commit('SET_LINKS', response.links);
           })
           .catch(handleError(commit));
@@ -152,6 +161,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           commit('STORE_RECORDS', response.data);
           commit('STORE_PAGE', response.data);
           commit('SET_LINKS', response.links);
+          commit('STORE_META', response.meta);
         });
       },
 
@@ -163,6 +173,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           commit('STORE_RECORDS', response.data);
           commit('STORE_PAGE', response.data);
           commit('SET_LINKS', response.links);
+          commit('STORE_META', response.meta);
         });
       },
 
@@ -180,6 +191,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
             const relatedIds = relatedRecords.map(record => record.id);
             commit('STORE_RECORDS', relatedRecords);
             commit('STORE_RELATED', { id, type, relatedIds });
+            commit('STORE_META', results.meta);
           })
           .catch(handleError(commit));
       },
@@ -212,6 +224,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       all: state => state.records,
       lastCreated: state => state.lastCreated,
       byId: state => ({ id }) => state.records.find(r => r.id == id),
+      lastMeta: state => state.lastMeta,
       page: state =>
         state.records.filter(record => state.page.includes(record.id)),
       where: state => ({ filter }) => {

--- a/test/vuex-jsonapi.spec.js
+++ b/test/vuex-jsonapi.spec.js
@@ -51,6 +51,8 @@ describe('resourceModule()', () => {
         },
       ];
 
+      const meta = { metaKey: 'metaValue' };
+
       it('sets loading to true while loading', () => {
         api.get.mockResolvedValue({
           data: {
@@ -81,6 +83,7 @@ describe('resourceModule()', () => {
           api.get.mockResolvedValue({
             data: {
               data: records,
+              meta,
             },
           });
 
@@ -99,6 +102,11 @@ describe('resourceModule()', () => {
           const firstRecord = records[0];
           expect(firstRecord.id).toEqual('1');
           expect(firstRecord.attributes.title).toEqual('Foo');
+        });
+
+        it('exposes meta data returned', () => {
+          const { lastMeta } = store.getters;
+          expect(lastMeta).toEqual(meta);
         });
       });
 
@@ -223,6 +231,8 @@ describe('resourceModule()', () => {
         status: 'draft',
       };
 
+      const meta = { metaKey: 'metaValue' };
+
       it('sets loading to true while loading', () => {
         api.get.mockResolvedValue({
           data: {
@@ -263,6 +273,7 @@ describe('resourceModule()', () => {
           api.get.mockResolvedValue({
             data: {
               data: records,
+              meta,
             },
           });
 
@@ -299,6 +310,11 @@ describe('resourceModule()', () => {
           const firstRecord = records[0];
           expect(firstRecord.id).toEqual('2');
           expect(firstRecord.attributes.title).toEqual('Foo');
+        });
+
+        it('exposes meta data returned', () => {
+          const { lastMeta } = store.getters;
+          expect(lastMeta).toEqual(meta);
         });
       });
 
@@ -380,6 +396,12 @@ describe('resourceModule()', () => {
         });
 
         describe('success', () => {
+          const meta = {
+            totalItems: 23,
+            itemsPerPage: 10,
+            currentPage: 1,
+          };
+
           beforeEach(() => {
             api.get.mockResolvedValue({
               data: {
@@ -388,6 +410,7 @@ describe('resourceModule()', () => {
                   next:
                     'https://api.example.com/widgets?page[number]=2&page[size]=2',
                 },
+                meta,
               },
             });
 
@@ -427,6 +450,11 @@ describe('resourceModule()', () => {
             const { hasPrevious } = store.getters;
             expect(hasPrevious).toEqual(false);
           });
+
+          it('exposes meta data returned', () => {
+            const { lastMeta } = store.getters;
+            expect(lastMeta).toEqual(meta);
+          });
         });
 
         describe('error', () => {
@@ -457,6 +485,8 @@ describe('resourceModule()', () => {
       });
 
       describe('next page request', () => {
+        const meta = { metaKey: 'metaValue' };
+
         beforeEach(() => {
           api.get
             .mockResolvedValueOnce({
@@ -475,6 +505,7 @@ describe('resourceModule()', () => {
                   prev:
                     'https://api.example.com/widgets?page[number]=1&page[size]=2',
                 },
+                meta,
               },
             });
 
@@ -512,9 +543,16 @@ describe('resourceModule()', () => {
           const { hasPrevious } = store.getters;
           expect(hasPrevious).toEqual(true);
         });
+
+        it('exposes meta data returned', () => {
+          const { lastMeta } = store.getters;
+          expect(lastMeta).toEqual(meta);
+        });
       });
 
       describe('previous page request', () => {
+        const meta = { metaKey: 'metaValue' };
+
         beforeEach(() => {
           api.get
             .mockResolvedValueOnce({
@@ -533,6 +571,7 @@ describe('resourceModule()', () => {
                   next:
                     'https://api.example.com/widgets?page[number]=2&page[size]=2',
                 },
+                meta,
               },
             });
 
@@ -569,6 +608,11 @@ describe('resourceModule()', () => {
         it('exposes whether there is a previous page', () => {
           const { hasPrevious } = store.getters;
           expect(hasPrevious).toEqual(false);
+        });
+
+        it('exposes meta data returned', () => {
+          const { lastMeta } = store.getters;
+          expect(lastMeta).toEqual(meta);
         });
       });
 
@@ -718,11 +762,14 @@ describe('resourceModule()', () => {
         },
       };
 
+      const meta = { metaKey: 'metaValue' };
+
       describe('success', () => {
         beforeEach(() => {
           api.get.mockResolvedValue({
             data: {
               data: record,
+              meta,
             },
           });
         });
@@ -784,6 +831,11 @@ describe('resourceModule()', () => {
 
             const storedRecord = records.find(r => r.id === id);
             expect(storedRecord.attributes.title).toEqual('New Title');
+          });
+
+          it('exposes meta data returned', () => {
+            const { lastMeta } = store.getters;
+            expect(lastMeta).toEqual(meta);
           });
         });
 
@@ -865,6 +917,8 @@ describe('resourceModule()', () => {
         id: '42',
       };
 
+      const meta = { metaKey: 'metaValue' };
+
       it('sets loading to true while loading', () => {
         api.get.mockResolvedValue({
           data: {
@@ -896,6 +950,7 @@ describe('resourceModule()', () => {
             api.get.mockResolvedValue({
               data: {
                 data: records,
+                meta,
               },
             });
 
@@ -913,6 +968,11 @@ describe('resourceModule()', () => {
           it('allows retrieving related records', () => {
             const records = store.getters.related({ parent });
             expect(records.length).toEqual(2);
+          });
+
+          it('exposes meta data returned', () => {
+            const { lastMeta } = store.getters;
+            expect(lastMeta).toEqual(meta);
           });
         });
 


### PR DESCRIPTION
Exposes the last `meta` properties returned by a GET request. This can be useful for pagination values, for example.

Addresses #22 