### PR TITLE
Error getter

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -7,8 +7,8 @@
       />
       <button>Create</button>
     </form>
-    <p v-if="loading">Loading...</p>
-    <p v-else-if="error">Error loading posts.</p>
+    <p v-if="isLoading">Loading...</p>
+    <p v-else-if="isError">Error loading posts</p>
     <ul v-else>
       <li
         v-for="post in allPosts"
@@ -54,7 +54,8 @@ export default {
   },
   computed: {
     ...mapGetters({
-      loading: 'posts/loading',
+      isLoading: 'posts/isLoading',
+      isError: 'posts/isError',
       error: 'posts/error',
       allPosts: 'posts/all',
     }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
-    "@reststate/client": "^0.0.4"
+    "@reststate/client": "^0.0.5"
   },
   "peerDependencies": {
     "vuex": "^3.0.1"

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -17,9 +17,10 @@ const storeRecord = records => newRecord => {
 const matches = criteria => test =>
   Object.keys(criteria).every(key => criteria[key] === test[key]);
 
-const handleError = commit => error => {
+const handleError = commit => errorResponse => {
   commit('SET_STATUS', STATUS_ERROR);
-  throw error;
+  commit('STORE_ERROR', errorResponse);
+  throw errorResponse;
 };
 
 const resourceModule = ({ name: resourceName, httpClient }) => {
@@ -70,6 +71,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
 
       STORE_META: (state, meta) => {
         state.lastMeta = meta;
+      },
+
+      STORE_ERROR: (state, error) => {
+        state.error = error;
       },
 
       STORE_RELATED: (state, parent) => {
@@ -219,6 +224,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
     getters: {
       isLoading: state => state.status === STATUS_LOADING,
       isError: state => state.status === STATUS_ERROR,
+      error: state => state.error,
       hasPrevious: state => !!state.links.prev,
       hasNext: state => !!state.links.next,
       all: state => state.records,

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -34,6 +34,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       related: [],
       filtered: [],
       page: [],
+      error: null,
       status: STATUS_INITIAL,
       links: {},
       lastCreated: null,

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -217,8 +217,8 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
     },
 
     getters: {
-      loading: state => state.status === STATUS_LOADING,
-      error: state => state.status === STATUS_ERROR,
+      isLoading: state => state.status === STATUS_LOADING,
+      isError: state => state.status === STATUS_ERROR,
       hasPrevious: state => !!state.links.prev,
       hasNext: state => !!state.links.next,
       all: state => state.records,

--- a/test/vuex-jsonapi.spec.js
+++ b/test/vuex-jsonapi.spec.js
@@ -201,6 +201,12 @@ describe('resourceModule()', () => {
           });
         });
 
+        it('exposes the error response', () => {
+          return response.catch(() => {
+            expect(store.getters.error).toEqual(error);
+          });
+        });
+
         it('sets loading to false', () => {
           return response.catch(() => {
             expect(store.getters.isLoading).toEqual(false);
@@ -335,6 +341,12 @@ describe('resourceModule()', () => {
         it('sets the error flag', () => {
           return response.catch(() => {
             expect(store.getters.isError).toEqual(true);
+          });
+        });
+
+        it('exposes the error response', () => {
+          return response.catch(() => {
+            expect(store.getters.error).toEqual(error);
           });
         });
       });
@@ -479,6 +491,12 @@ describe('resourceModule()', () => {
           it('sets the error flag', () => {
             return response.catch(() => {
               expect(store.getters.isError).toEqual(true);
+            });
+          });
+
+          it('exposes the error response', () => {
+            return response.catch(() => {
+              expect(store.getters.error).toEqual(error);
             });
           });
         });
@@ -891,6 +909,12 @@ describe('resourceModule()', () => {
             expect(store.getters.isError).toEqual(true);
           });
         });
+
+        it('exposes the error response', () => {
+          return response.catch(() => {
+            expect(store.getters.error).toEqual(error);
+          });
+        });
       });
     });
 
@@ -1042,6 +1066,12 @@ describe('resourceModule()', () => {
         it('sets the error flag', () => {
           return response.catch(() => {
             expect(store.getters.isError).toEqual(true);
+          });
+        });
+
+        it('exposes the error response', () => {
+          return response.catch(() => {
+            expect(store.getters.error).toEqual(error);
           });
         });
       });
@@ -1225,17 +1255,17 @@ describe('resourceModule()', () => {
     });
 
     describe('error', () => {
-      const error = { dummy: 'error' };
+      const errorResponse = { dummy: 'error' };
 
       let response;
 
       beforeEach(() => {
-        api.post.mockRejectedValue(error);
+        api.post.mockRejectedValue({ response: errorResponse });
         response = store.dispatch('create', widget);
       });
 
       it('rejects with the error', () => {
-        expect(response).rejects.toEqual(error);
+        expect(response).rejects.toEqual(errorResponse);
       });
     });
   });

--- a/test/vuex-jsonapi.spec.js
+++ b/test/vuex-jsonapi.spec.js
@@ -60,7 +60,7 @@ describe('resourceModule()', () => {
           },
         });
         store.dispatch('loadAll');
-        expect(store.getters.loading).toEqual(true);
+        expect(store.getters.isLoading).toEqual(true);
       });
 
       it('resets the error flag', () => {
@@ -74,7 +74,7 @@ describe('resourceModule()', () => {
           .dispatch('loadAll')
           .catch(() => store.dispatch('loadAll'))
           .then(() => {
-            expect(store.getters.error).toEqual(false);
+            expect(store.getters.isError).toEqual(false);
           });
       });
 
@@ -91,7 +91,7 @@ describe('resourceModule()', () => {
         });
 
         it('sets loading to false', () => {
-          expect(store.getters.loading).toEqual(false);
+          expect(store.getters.isLoading).toEqual(false);
         });
 
         it('makes the records accessible via getter', () => {
@@ -197,13 +197,13 @@ describe('resourceModule()', () => {
 
         it('sets the error flag', () => {
           return response.catch(() => {
-            expect(store.getters.error).toEqual(true);
+            expect(store.getters.isError).toEqual(true);
           });
         });
 
         it('sets loading to false', () => {
           return response.catch(() => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
         });
       });
@@ -240,7 +240,7 @@ describe('resourceModule()', () => {
           },
         });
         store.dispatch('loadWhere', { filter });
-        expect(store.getters.loading).toEqual(true);
+        expect(store.getters.isLoading).toEqual(true);
       });
 
       it('resets the error flag', () => {
@@ -254,7 +254,7 @@ describe('resourceModule()', () => {
           .dispatch('loadWhere', { filter })
           .catch(() => store.dispatch('loadWhere', { filter }))
           .then(() => {
-            expect(store.getters.error).toEqual(false);
+            expect(store.getters.isError).toEqual(false);
           });
       });
 
@@ -286,7 +286,7 @@ describe('resourceModule()', () => {
         });
 
         it('sets loading to false', () => {
-          expect(store.getters.loading).toEqual(false);
+          expect(store.getters.isLoading).toEqual(false);
         });
 
         it('passes the filter on to the server', () => {
@@ -334,7 +334,7 @@ describe('resourceModule()', () => {
 
         it('sets the error flag', () => {
           return response.catch(() => {
-            expect(store.getters.error).toEqual(true);
+            expect(store.getters.isError).toEqual(true);
           });
         });
       });
@@ -392,7 +392,7 @@ describe('resourceModule()', () => {
               'page[size]': 2,
             },
           });
-          expect(store.getters.loading).toEqual(true);
+          expect(store.getters.isLoading).toEqual(true);
         });
 
         describe('success', () => {
@@ -423,7 +423,7 @@ describe('resourceModule()', () => {
           });
 
           it('sets loading to false', () => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
 
           it('passes the pagination on to the server', () => {
@@ -478,7 +478,7 @@ describe('resourceModule()', () => {
 
           it('sets the error flag', () => {
             return response.catch(() => {
-              expect(store.getters.error).toEqual(true);
+              expect(store.getters.isError).toEqual(true);
             });
           });
         });
@@ -776,7 +776,7 @@ describe('resourceModule()', () => {
 
         it('sets loading to true while loading', () => {
           store.dispatch('loadById', { id });
-          expect(store.getters.loading).toEqual(true);
+          expect(store.getters.isLoading).toEqual(true);
         });
 
         it('resets the error flag', () => {
@@ -790,7 +790,7 @@ describe('resourceModule()', () => {
             .dispatch('loadById', { id })
             .catch(() => store.dispatch('loadById', { id }))
             .then(() => {
-              expect(store.getters.error).toEqual(false);
+              expect(store.getters.isError).toEqual(false);
             });
         });
 
@@ -821,7 +821,7 @@ describe('resourceModule()', () => {
           });
 
           it('sets loading to false', () => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
 
           it('adds the record to the list of all records', () => {
@@ -882,13 +882,13 @@ describe('resourceModule()', () => {
 
         it('sets loading to false', () => {
           return response.catch(() => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
         });
 
         it('sets the error flag', () => {
           return response.catch(() => {
-            expect(store.getters.error).toEqual(true);
+            expect(store.getters.isError).toEqual(true);
           });
         });
       });
@@ -926,7 +926,7 @@ describe('resourceModule()', () => {
           },
         });
         store.dispatch('loadRelated', { parent });
-        expect(store.getters.loading).toEqual(true);
+        expect(store.getters.isLoading).toEqual(true);
       });
 
       it('resets the error flag', () => {
@@ -940,7 +940,7 @@ describe('resourceModule()', () => {
           .dispatch('loadRelated', { parent })
           .catch(() => store.dispatch('loadRelated', { parent }))
           .then(() => {
-            expect(store.getters.error).toEqual(false);
+            expect(store.getters.isError).toEqual(false);
           });
       });
 
@@ -962,7 +962,7 @@ describe('resourceModule()', () => {
           });
 
           it('sets loading to false', () => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
 
           it('allows retrieving related records', () => {
@@ -1035,13 +1035,13 @@ describe('resourceModule()', () => {
 
         it('sets loading to false', () => {
           return response.catch(() => {
-            expect(store.getters.loading).toEqual(false);
+            expect(store.getters.isLoading).toEqual(false);
           });
         });
 
         it('sets the error flag', () => {
           return response.catch(() => {
-            expect(store.getters.error).toEqual(true);
+            expect(store.getters.isError).toEqual(true);
           });
         });
       });
@@ -1204,7 +1204,7 @@ describe('resourceModule()', () => {
       });
 
       it('sets loading to false', () => {
-        expect(store.getters.loading).toEqual(false);
+        expect(store.getters.isLoading).toEqual(false);
       });
 
       it('adds the record to the list', () => {


### PR DESCRIPTION
When an error occurs during a data load, this exposes the error response via the `error` getter.

Previously the `error` getter exposed a boolean indicating whether an error occurred; this renames that getter to `isError`, as well as the similar `loading` to `isLoading`.

Partially addresses #24. This PR does not yet expose errors in write operations via this getter; doing so will require larger design changes.