### PR TITLE
Store and remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -220,6 +220,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           commit('REMOVE_RECORD', record);
         });
       },
+
+      storeRecord({ commit }, record) {
+        commit('STORE_RECORD', record);
+      },
     },
 
     getters: {

--- a/src/vuex-jsonapi.js
+++ b/src/vuex-jsonapi.js
@@ -224,6 +224,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       storeRecord({ commit }, record) {
         commit('STORE_RECORD', record);
       },
+
+      removeRecord({ commit }, record) {
+        commit('REMOVE_RECORD', record);
+      },
     },
 
     getters: {

--- a/test/vuex-jsonapi.spec.js
+++ b/test/vuex-jsonapi.spec.js
@@ -1078,6 +1078,50 @@ describe('resourceModule()', () => {
     });
   });
 
+  describe('pushing changes into the store', () => {
+    describe('adding records', () => {
+      const record = {
+        type: 'widget',
+        id: '42',
+        attributes: {
+          title: 'Bar',
+        },
+      };
+
+      describe('when the record does not yet exist', () => {
+        it('adds the record', () => {
+          return store.dispatch('storeRecord', record).then(() => {
+            const records = store.getters.all;
+            expect(records.length).toEqual(1);
+            const firstRecord = records[0];
+            expect(firstRecord.attributes.title).toEqual('Bar');
+          });
+        });
+      });
+
+      describe('when the record already exists', () => {
+        it('replaces the record', () => {
+          store.commit('REPLACE_ALL_RECORDS', [
+            {
+              type: 'widget',
+              id: '42',
+              attributes: {
+                title: 'Foo',
+              },
+            },
+          ]);
+
+          store.dispatch('storeRecord', record).then(() => {
+            const records = store.getters.all;
+            expect(records.length).toEqual(1);
+            const firstRecord = records[0];
+            expect(firstRecord.attributes.title).toEqual('Bar');
+          });
+        });
+      });
+    });
+  });
+
   describe('retrieving from the store', () => {
     beforeEach(() => {
       store.commit('REPLACE_ALL_RECORDS', [

--- a/test/vuex-jsonapi.spec.js
+++ b/test/vuex-jsonapi.spec.js
@@ -1120,6 +1120,36 @@ describe('resourceModule()', () => {
         });
       });
     });
+
+    describe('removing records', () => {
+      it('removes the record from the store', () => {
+        const record = {
+          type: 'widget',
+          id: '42',
+          attributes: {
+            title: 'Foo',
+          },
+        };
+
+        store.commit('REPLACE_ALL_RECORDS', [
+          record,
+          {
+            type: 'widget',
+            id: '27',
+            attributes: {
+              title: 'Bar',
+            },
+          },
+        ]);
+
+        store.dispatch('removeRecord', record).then(() => {
+          const records = store.getters.all;
+          expect(records.length).toEqual(1);
+          const firstRecord = records[0];
+          expect(firstRecord.attributes.title).toEqual('Bar');
+        });
+      });
+    });
   });
 
   describe('retrieving from the store', () => {


### PR DESCRIPTION
Add ability to store and remove records in the store, without sending requests to the server. This can be used, for example, to update the store with changes pushed to the app via websockets.

```javascript
this.$store.dispatch('widgets/storeRecord', record);
this.$store.dispatch('widgets/removeRecord', record);
````