### PR TITLE
feat: store included data after load data by id

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docs:build": "vuepress build docs"
   },
   "dependencies": {
-    "@reststate/client": "^0.0.8"
+    "@reststate/client": "^0.0.8",
+    "pluralize": "^7.0.0"
   },
   "peerDependencies": {
     "vuex": "^3.0.1"

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -214,12 +214,20 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
               const relatedRecords = results.data;
               const relatedIds = relatedRecords.map(record => record.id);
               commit('STORE_RECORDS', relatedRecords);
-              commit('STORE_RELATED', { ...params, relatedIds });
+              commit('STORE_RELATED', {
+                parent: { id, type },
+                relationship,
+                relatedIds,
+              });
             } else {
               const record = results.data;
               const relatedIds = record.id;
               commit('STORE_RECORDS', [record]);
-              commit('STORE_RELATED', { ...params, relatedIds });
+              commit('STORE_RELATED', {
+                parent: { id, type },
+                relationship,
+                relatedIds,
+              });
             }
             commit('STORE_META', results.meta);
             return dispatch('handleCompoundDocument', results);

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -276,10 +276,6 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       },
 
       storeIncluded({ commit, dispatch }, { data, included }) {
-        Object.keys(data.relationships).forEach(key => {
-          if (!data.relationships[key].data) delete data.relationships[key];
-        });
-
         const relationshipsMap = new Map(Object.entries(data.relationships));
         const existingResourceNames = Object.keys(this._modules.root._children);
         const parent = {

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -292,15 +292,6 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           commit(`${resourceName}/STORE_RECORDS`, [record], {
             root: true,
           });
-          commit(
-            `${resourceName}/STORE_RELATED`,
-            {
-              parent,
-              relationship: record.type,
-              relatedIds: record.id,
-            },
-            { root: true },
-          );
         }
 
         for (const relationship in data.relationships) {

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -1,5 +1,6 @@
 import { ResourceClient } from '@reststate/client';
 import deepEquals from './deepEquals';
+import pluralize from 'pluralize';
 
 const STATUS_INITIAL = 'INITIAL';
 const STATUS_LOADING = 'LOADING';
@@ -133,7 +134,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           .catch(handleError(commit));
       },
 
-      loadById({ commit }, { id, options }) {
+      loadById({ commit, dispatch }, { id, options }) {
         commit('SET_STATUS', STATUS_LOADING);
         return client
           .find({ id, options })
@@ -141,6 +142,8 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
             commit('SET_STATUS', STATUS_SUCCESS);
             commit('STORE_RECORD', results.data);
             commit('STORE_META', results.meta);
+
+            return dispatch('storeIncluded', results);
           })
           .catch(handleError(commit));
       },
@@ -199,7 +202,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         });
       },
 
-      loadRelated({ commit }, params) {
+      loadRelated({ commit, dispatch }, params) {
         const { parent, relationship = resourceName, options } = params;
         commit('SET_STATUS', STATUS_LOADING);
         return client
@@ -219,6 +222,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
               commit('STORE_RELATED', { ...params, relatedIds });
             }
             commit('STORE_META', results.meta);
+            return dispatch('storeIncluded', results);
           })
           .catch(handleError(commit));
       },
@@ -252,6 +256,99 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
 
       resetState({ commit }) {
         commit('RESET_STATE');
+      },
+
+      storeIncluded({ commit, dispatch }, { data, included }) {
+        if (!included || !Array.isArray(included)) return;
+
+        const existingResourceNames = Object.keys(this._modules.root._children);
+
+        if (Array.isArray(data)) {
+          return Promise.all(
+            data.map(datum => {
+              return dispatch('storeIncluded', {
+                data: datum,
+                included,
+              });
+            }),
+          );
+        } else {
+          Object.keys(data.relationships).forEach(key => {
+            if (!data.relationships[key].data) delete data.relationships[key];
+          });
+          const relationshipsMap = new Map(Object.entries(data.relationships));
+
+          const parent = {
+            id: data.id,
+            type: data.type,
+          };
+
+          relationshipsMap.forEach(({ data }, relationship) => {
+            if (!data || data.length === 0) return;
+
+            if (Array.isArray(data)) {
+              const targetResourceName = pluralize(data[0].type);
+
+              if (
+                !existingResourceNames.find(name => name === targetResourceName)
+              )
+                return;
+
+              const records = data
+                .map(relationshipData =>
+                  included.find(
+                    includedItem => relationshipData.id === includedItem.id,
+                  ),
+                )
+                .filter(record => !!record);
+
+              const relatedIds = records.map(r => r.id);
+
+              commit(`${targetResourceName}/STORE_RECORDS`, records, {
+                root: true,
+              });
+              commit(
+                `${targetResourceName}/STORE_RELATED`,
+                { parent, relationship, relatedIds },
+                { root: true },
+              );
+              commit(`${targetResourceName}/SET_STATUS`, STATUS_SUCCESS, {
+                root: true,
+              });
+
+              return records;
+            } else {
+              const targetResourceName = pluralize(data.type);
+
+              if (
+                !existingResourceNames.find(name => name === targetResourceName)
+              )
+                return;
+
+              const record = included.find(
+                includedItem => data.id === includedItem.id,
+              );
+
+              if (!record) return;
+
+              const relatedIds = record.id;
+
+              commit(`${targetResourceName}/STORE_RECORDS`, [record], {
+                root: true,
+              });
+              commit(
+                `${targetResourceName}/STORE_RELATED`,
+                { parent, relationship, relatedIds },
+                { root: true },
+              );
+              commit(`${targetResourceName}/SET_STATUS`, STATUS_SUCCESS, {
+                root: true,
+              });
+
+              return record;
+            }
+          });
+        }
       },
     },
 


### PR DESCRIPTION
changes:
  - add new action 'storeIncluded':
    - scan all included items if included array exists
    - store record in existing resource module
    - store related data either to use related getter
  - dispatch 'storeIncluded' after load resource by id
  - add pluralize.js to get resource name from resource type

Signed-off-by: cmygray <cmygray@gmail.com>