### PR TITLE
Included Records

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -62,7 +62,7 @@ const storeIncluded = ({ commit, dispatch }, result) => {
           const options = {
             relatedIds,
             params: {
-              parent: { type: primaryRecord.type, id: primaryRecord.id },
+              parent: getResourceIdentifier(primaryRecord),
             },
           };
           const action = `${type}/storeRelated`;

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -39,8 +39,9 @@ const storeIncluded = ({ commit, dispatch }, result) => {
       dispatch(action, relatedRecord, { root: true });
     });
 
-    // store the relationship to the primary records
-    result.data.forEach(primaryRecord => {
+    // store the relationship for primary and secondary records
+    const allRecords = [...result.data, ...result.included];
+    allRecords.forEach(primaryRecord => {
       if (primaryRecord.relationships) {
         Object.keys(primaryRecord.relationships).forEach(relationshipName => {
           const relationship = primaryRecord.relationships[relationshipName];

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -49,11 +49,16 @@ const storeIncluded = ({ commit, dispatch }, result) => {
             return;
           }
 
-          // TODO: maybe not all might have the same type
-          const { type } = relationship.data[0];
-          const relatedIds = relationship.data.map(
-            relatedRecord => relatedRecord.id,
-          );
+          let type, relatedIds;
+          if (Array.isArray(relationship.data)) {
+            // TODO: maybe not all might have the same type
+            ({ type } = relationship.data[0]);
+            relatedIds = relationship.data.map(
+              relatedRecord => relatedRecord.id,
+            );
+          } else {
+            ({ type, id: relatedIds } = relationship.data);
+          }
           const options = {
             relatedIds,
             params: {

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -15,6 +15,16 @@ const storeRecord = records => newRecord => {
   }
 };
 
+const storeIncluded = ({ dispatch }, records) => {
+  if (!records) {
+    return;
+  }
+  records.forEach(record => {
+    const action = `${record.type}/storeRecord`;
+    dispatch(action, record, { root: true });
+  });
+};
+
 const matches = criteria => test =>
   Object.keys(criteria).every(key => deepEquals(criteria[key], test[key]));
 
@@ -121,7 +131,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
     },
 
     actions: {
-      loadAll({ commit }, { options } = {}) {
+      loadAll({ commit, dispatch }, { options } = {}) {
         commit('SET_STATUS', STATUS_LOADING);
         return client
           .all({ options })
@@ -129,6 +139,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
             commit('SET_STATUS', STATUS_SUCCESS);
             commit('REPLACE_ALL_RECORDS', result.data);
             commit('STORE_META', result.meta);
+            storeIncluded({ dispatch }, result.included);
           })
           .catch(handleError(commit));
       },

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -15,6 +15,22 @@ const storeRecord = records => newRecord => {
   }
 };
 
+const getResourceIdentifier = resource => {
+  if (!resource) {
+    return resource;
+  }
+
+  return {
+    type: resource.type,
+    id: resource.id,
+  };
+};
+
+const paramsWithParentIdentifierOnly = params => ({
+  ...params,
+  parent: getResourceIdentifier(params.parent),
+});
+
 const storeIncluded = ({ commit, dispatch }, result) => {
   if (result.included) {
     // store the included records
@@ -284,7 +300,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       },
 
       storeRelated({ commit }, { relatedIds, params }) {
-        commit('STORE_RELATED', { relatedIds, params });
+        commit('STORE_RELATED', {
+          relatedIds,
+          params: paramsWithParentIdentifierOnly(params),
+        });
       },
 
       removeRecord({ commit }, record) {
@@ -319,7 +338,9 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         return ids.map(id => state.records.find(record => record.id === id));
       },
       related: state => params => {
-        const related = state.related.find(matches(params));
+        const related = state.related.find(
+          matches(paramsWithParentIdentifierOnly(params)),
+        );
 
         if (!related) {
           return null;

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1349,8 +1349,7 @@ describe('resourceModule()', () => {
       });
 
       it('makes the included records accessible via relationship', () => {
-        const primaryRecord = primaryRecords[1];
-        const parent = { type: primaryRecord.type, id: primaryRecord.id }; // TODO: don't require it to have this exact format
+        const parent = primaryRecords[1];
         const records = multiStore.getters['dishes/related']({ parent });
 
         expect(records.length).toEqual(1);

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1347,6 +1347,17 @@ describe('resourceModule()', () => {
         expect(firstRecord.id).toEqual('1');
         expect(firstRecord.attributes.name).toEqual('California Roll');
       });
+
+      it('makes the included records accessible via relationship', () => {
+        const primaryRecord = primaryRecords[1];
+        const parent = { type: primaryRecord.type, id: primaryRecord.id }; // TODO: don't require it to have this exact format
+        const records = multiStore.getters['dishes/related']({ parent });
+
+        expect(records.length).toEqual(1);
+        const firstRecord = records[0];
+        expect(firstRecord.id).toEqual('3');
+        expect(firstRecord.attributes.name).toEqual('Avocado Burger');
+      });
     });
   });
 

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1337,6 +1337,16 @@ describe('resourceModule()', () => {
         expect(firstRecord.id).toEqual('1');
         expect(firstRecord.attributes.name).toEqual('Sushi Place');
       });
+
+      it('makes the included records accessible via getter', () => {
+        const records = multiStore.getters['dishes/all'];
+
+        expect(records.length).toEqual(3);
+
+        const firstRecord = records[0];
+        expect(firstRecord.id).toEqual('1');
+        expect(firstRecord.attributes.name).toEqual('California Roll');
+      });
     });
   });
 

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1286,6 +1286,16 @@ describe('resourceModule()', () => {
           attributes: {
             name: 'California Roll',
           },
+          relationships: {
+            comments: {
+              data: [
+                {
+                  type: 'comments',
+                  id: '1',
+                },
+              ],
+            },
+          },
         },
         {
           type: 'dishes',
@@ -1299,6 +1309,13 @@ describe('resourceModule()', () => {
           id: '3',
           attributes: {
             name: 'Avocado Burger',
+          },
+        },
+        {
+          type: 'comments',
+          id: '1',
+          attributes: {
+            text: 'my favorite',
           },
         },
       ];
@@ -1316,7 +1333,7 @@ describe('resourceModule()', () => {
         });
 
         const modules = mapResourceModules({
-          names: ['restaurants', 'dishes'],
+          names: ['restaurants', 'dishes', 'comments'],
           httpClient: api,
         });
         multiStore = new Vuex.Store({
@@ -1324,7 +1341,7 @@ describe('resourceModule()', () => {
         });
 
         return multiStore.dispatch('restaurants/loadAll', {
-          include: 'dishes',
+          include: 'dishes,dishes.comments',
         });
       });
 
@@ -1356,6 +1373,16 @@ describe('resourceModule()', () => {
         const firstRecord = records[0];
         expect(firstRecord.id).toEqual('3');
         expect(firstRecord.attributes.name).toEqual('Avocado Burger');
+      });
+
+      it('allows including records multiple levels deep', () => {
+        const parent = { type: 'dishes', id: '1' };
+        const records = multiStore.getters['comments/related']({ parent });
+
+        expect(records.length).toEqual(1);
+        const firstRecord = records[0];
+        expect(firstRecord.id).toEqual('1');
+        expect(firstRecord.attributes.text).toEqual('my favorite');
       });
     });
   });


### PR DESCRIPTION
Allows querying for included records, and they will be stored in the appropriate module and indexed as related data. Supports both to-one and to-many relationships.

The JSON:API spec way to query for included records is to include an `?include=relationship,relationship.nested` query parameter. Reststate-Vuex doesn't specifically check for that; instead, it checks the returned data:

- If there is an `included` key at the root of the JSON:API response objects, all of those records are stored. Because they will often not be of the same type as the module you first queried (for example, if you are querying for `posts` and you include `comments`), reststate-vuex assumes there is another module of the same name as the `type` of the resource. This will be the case if you created the modules with `mapResourceModules({ names: ['posts', 'comments'] })`.
- For any records in `data` or in `included` that have a `relationships` key, we check for relationships that have `data` — that is, that the actual resource identifiers for the related records have been included. If found, we keep a record of that relationship, so the data can be retrieved by the `related` getter.

For examples of this in action, see `describe('included')` in the tests.