### PR TITLE
Parent bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -147,7 +147,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         if (existingRecord) {
           existingRecord.relatedIds = relatedIds;
         } else {
-          related.push(Object.assign({ relatedIds }, params));
+          related.push(Object.assign({ relatedIds }, paramsWithParentID));
         }
       },
 
@@ -309,7 +309,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       storeRelated({ commit }, { relatedIds, params }) {
         commit('STORE_RELATED', {
           relatedIds,
-          params: paramsWithParentIdentifierOnly(params),
+          params,
         });
       },
 

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -141,8 +141,9 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
 
       STORE_RELATED: (state, { relatedIds, params }) => {
         const { related } = state;
+        const paramsWithParentID = paramsWithParentIdentifierOnly(params);
 
-        const existingRecord = related.find(matches(params));
+        const existingRecord = related.find(matches(paramsWithParentID));
         if (existingRecord) {
           existingRecord.relatedIds = relatedIds;
         } else {
@@ -344,9 +345,8 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         return ids.map(id => state.records.find(record => record.id === id));
       },
       related: state => params => {
-        const related = state.related.find(
-          matches(paramsWithParentIdentifierOnly(params)),
-        );
+        const paramsWithParentID = paramsWithParentIdentifierOnly(params);
+        const related = state.related.find(matches(paramsWithParentID));
 
         if (!related) {
           return null;

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1032,6 +1032,9 @@ describe('resourceModule()', () => {
       const parent = {
         type: 'users',
         id: '42',
+        attributes: {
+          name: 'fred',
+        },
       };
 
       const meta = { metaKey: 'metaValue' };
@@ -1082,8 +1085,17 @@ describe('resourceModule()', () => {
             expect(store.getters.isLoading).toEqual(false);
           });
 
-          it('allows retrieving related records', () => {
+          it('allows retrieving related records by full parent', () => {
             const records = store.getters.related({ parent });
+            expect(records.length).toEqual(2);
+          });
+
+          it('allows retrieving related records by parent identifier', () => {
+            const parentIdentifier = {
+              id: parent.id,
+              type: parent.type,
+            };
+            const records = store.getters.related({ parent: parentIdentifier });
             expect(records.length).toEqual(2);
           });
 


### PR DESCRIPTION
Fixes a bug where records loaded with `loadRelated`, when passed a full record, could not be retrieved as related either by the full parent record or by record identifier. This is because the related records were indexed by the full parent record, but whatever you passed in to look them up, it was converted to a record identifier.

We fix this by moving the conversion to a record identifier out of the `storeRelated` action into the `STORE_RELATED` mutation. This ensures that wherever that mutation is called from, the parent is converted to a record identifier before indexing.