### PR TITLE
Named relationships

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -69,6 +69,7 @@ const storeIncluded = ({ commit, dispatch }, result) => {
             relatedIds,
             params: {
               parent: getResourceIdentifier(primaryRecord),
+              relationship: relationshipName,
             },
           };
           const action = `${type}/storeRelated`;

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -274,6 +274,10 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       loadRelated({ commit, dispatch }, params) {
         const { parent, relationship = resourceName, options } = params;
         commit('SET_STATUS', STATUS_LOADING);
+        const paramsToStore = {
+          ...params,
+          relationship,
+        };
         return client
           .related({ parent, relationship, options })
           .then(results => {
@@ -283,12 +287,12 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
               const relatedRecords = results.data;
               const relatedIds = relatedRecords.map(record => record.id);
               commit('STORE_RECORDS', relatedRecords);
-              commit('STORE_RELATED', { params, relatedIds });
+              commit('STORE_RELATED', { params: paramsToStore, relatedIds });
             } else {
               const record = results.data;
               const relatedIds = record.id;
               commit('STORE_RECORDS', [record]);
-              commit('STORE_RELATED', { params, relatedIds });
+              commit('STORE_RELATED', { params: paramsToStore, relatedIds });
             }
             commit('STORE_META', results.meta);
             storeIncluded({ commit, dispatch }, results);

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -359,6 +359,11 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
       },
       related: state => params => {
         const paramsWithParentID = paramsWithParentIdentifierOnly(params);
+
+        if (!paramsWithParentID.relationship) {
+          paramsWithParentID.relationship = resourceName;
+        }
+
         const related = state.related.find(matches(paramsWithParentID));
 
         if (!related) {

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1659,6 +1659,73 @@ describe('resourceModule()', function() {
               expect(child.id).toEqual('3');
             });
         });
+
+        it('retrieves the relationship with the same name as the resource if the name is not specified', () => {
+          const primaryRecord = {
+            type: 'posts',
+            id: '1',
+            relationships: {
+              secretComments: {
+                data: [
+                  {
+                    type: 'comments',
+                    id: '2',
+                  },
+                ],
+              },
+              comments: {
+                data: [
+                  {
+                    type: 'comments',
+                    id: '1',
+                  },
+                ],
+              },
+            },
+          };
+
+          const includedRecords = [
+            {
+              type: 'comments',
+              id: '1',
+            },
+            {
+              type: 'comments',
+              id: '2',
+            },
+          ];
+
+          const response = {
+            data: primaryRecord,
+            included: includedRecords,
+          };
+
+          api.get.mockResolvedValue({
+            data: response,
+          });
+
+          const modules = mapResourceModules({
+            names: ['posts', 'comments'],
+            httpClient: api,
+          });
+          const store = new Vuex.Store({ modules });
+
+          return store
+            .dispatch('posts/loadById', {
+              id: '1',
+              options: {
+                include: 'comments,secretComments',
+              },
+            })
+            .then(() => {
+              const comments = store.getters['comments/related']({
+                parent: primaryRecord,
+              });
+
+              expect(comments.length).toEqual(1);
+              expect(comments[0].id).toEqual('1');
+            });
+        });
       });
     });
   });

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1465,6 +1465,7 @@ describe('resourceModule()', function() {
             const parent = this.primaryRecords[0];
             const record = this.multiStore.getters['restaurants/related']({
               parent,
+              relationship: 'restaurant',
             });
 
             expect(record.id).toEqual('1');


### PR DESCRIPTION
Correctly index by and allow specifying the relationship name, defaulting to the same name as the resource.