### PR TITLE
Don't index options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reststate/vuex",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Library to access JSON:API data via Vuex stores",
   "main": "index.js",
   "repository": "git@github.com:reststate/reststate-vuex.git",

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -26,11 +26,6 @@ const getResourceIdentifier = resource => {
   };
 };
 
-const paramsWithParentIdentifierOnly = params => ({
-  ...params,
-  parent: getResourceIdentifier(params.parent),
-});
-
 const storeIncluded = ({ commit, dispatch }, result) => {
   if (result.included) {
     // store the included records
@@ -104,6 +99,16 @@ const initialState = () => ({
 const resourceModule = ({ name: resourceName, httpClient }) => {
   const client = new ResourceClient({ name: resourceName, httpClient });
 
+  const getRelationshipIndex = params => {
+    const { parent, relationship = resourceName } = params;
+    const parentResourceIdentifier = getResourceIdentifier(parent);
+
+    return {
+      parent: parentResourceIdentifier,
+      relationship,
+    };
+  };
+
   return {
     namespaced: true,
 
@@ -148,13 +153,13 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
 
       STORE_RELATED: (state, { relatedIds, params }) => {
         const { related } = state;
-        const paramsWithParentID = paramsWithParentIdentifierOnly(params);
+        const relationshipIndex = getRelationshipIndex(params);
 
-        const existingRecord = related.find(matches(paramsWithParentID));
+        const existingRecord = related.find(matches(relationshipIndex));
         if (existingRecord) {
           existingRecord.relatedIds = relatedIds;
         } else {
-          related.push(Object.assign({ relatedIds }, paramsWithParentID));
+          related.push(Object.assign({ relatedIds }, relationshipIndex));
         }
       },
 
@@ -362,13 +367,8 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         return ids.map(id => state.records.find(record => record.id === id));
       },
       related: state => params => {
-        const paramsWithParentID = paramsWithParentIdentifierOnly(params);
-
-        if (!paramsWithParentID.relationship) {
-          paramsWithParentID.relationship = resourceName;
-        }
-
-        const related = state.related.find(matches(paramsWithParentID));
+        const relationshipIndex = getRelationshipIndex(params);
+        const related = state.related.find(matches(relationshipIndex));
 
         if (!related) {
           return null;

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1206,10 +1206,7 @@ describe('resourceModule()', function() {
           });
 
           it('returns the second set of records', () => {
-            const records = store.getters.related({
-              parent,
-              options: secondOptions,
-            });
+            const records = store.getters.related({ parent });
             expect(records).toEqual(reversedRecords);
           });
         });


### PR DESCRIPTION
Previously we indexed relationships based on all the params passed. But this got complex in cases where, for example, you _initially_ loaded a relationship included from another resource, but then _reloaded_ it directly. One might have options and the other might not.

Indexing based on options is also complex because some should be indexed separately and others should not. Theoretically you might index the results of the relationship with different filters separately, but you don't care if the `include` changes.

For now, we take the simplest approach that is more consistent: we never index relationships based on options, only based on parent reference object and relationship name. This does mean we don't keep different filter results indexed in memory; if users find that we need that, we can look into it.