### PR TITLE
When updating a record, update its cached related data too

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -317,14 +317,20 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           commit('STORE_RECORD', record);
           if (record.relationships) {
             for (const relationship of Object.keys(record.relationships)) {
-              if (record.relationships[relationship].data) {
-                // TODO: if (Array.isArray(results.data)) {
+              const { data } = record.relationships[relationship];
+              if (data) {
                 const paramsToStore = {
                   parent: getResourceIdentifier(record),
                   relationship,
                 };
-                const { type, id } = record.relationships[relationship].data;
-                const relatedIds = id;
+                let type, id, relatedIds;
+                if (Array.isArray(data)) {
+                  ({ type } = data[0]);
+                  relatedIds = data.map(record => record.id);
+                } else {
+                  ({ type, id } = data);
+                  relatedIds = id;
+                }
                 dispatch(
                   `${type}/storeRelated`,
                   {

--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -312,9 +312,30 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
         });
       },
 
-      update({ commit }, record) {
+      update({ commit, dispatch }, record) {
         return client.update(record).then(() => {
           commit('STORE_RECORD', record);
+          if (record.relationships) {
+            for (const relationship of Object.keys(record.relationships)) {
+              if (record.relationships[relationship].data) {
+                // TODO: if (Array.isArray(results.data)) {
+                const paramsToStore = {
+                  parent: getResourceIdentifier(record),
+                  relationship,
+                };
+                const { type, id } = record.relationships[relationship].data;
+                const relatedIds = id;
+                dispatch(
+                  `${type}/storeRelated`,
+                  {
+                    params: paramsToStore,
+                    relatedIds,
+                  },
+                  { root: true },
+                );
+              }
+            }
+          }
         });
       },
 


### PR DESCRIPTION
Fixes #161 

When you update a record including a `relationships` field, then use the `related` getter to retrieve the records for that relationship, you should get the new list of records that was updated. But previously this wasn't happening; the list of related records was only updated when loading from the server.

This PR fixes that, updating the cached list of related record IDs when you update a record.