### PR TITLE
Skip records that are not found after delete

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -374,7 +374,9 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           return null;
         } else if (Array.isArray(related.relatedIds)) {
           const ids = related.relatedIds;
-          return ids.map(id => state.records.find(record => record.id === id));
+          return ids
+            .map(id => state.records.find(record => record.id === id))
+            .filter(record => record !== undefined);
         } else {
           const id = related.relatedIds;
           return state.records.find(record => id === record.id);

--- a/test/reststate-vuex.spec.js
+++ b/test/reststate-vuex.spec.js
@@ -1244,6 +1244,26 @@ describe('resourceModule()', function () {
           });
         });
       });
+
+      it('skips records that are not found', () => {
+        api.get.mockResolvedValue({
+          data: {
+            data: records,
+            meta,
+          },
+        });
+        api.delete.mockResolvedValue();
+
+        return store
+          .dispatch('loadRelated', { parent })
+          .then(() => {
+            return store.dispatch('delete', records[0]);
+          })
+          .then(() => {
+            const records = store.getters.related({ parent });
+            expect(records.length).toEqual(1);
+          });
+      });
     });
 
     describe('included', () => {


### PR DESCRIPTION
Fixes #180 

Previously, if you deleted a record, then accessed a relationship that pointed to that record, the ID would not be found, so you would get an `undefined` in your results.

This PR updates this to skip over the missing record, so you only get back records that are found.

The assumption is that if you want to access that relationship you will have pulled down all related records in the cache. If an ID is not found, it is because that ID in the relationship is out of date. And in any case, a getter shouldn't dispatch actions, so we would not want to automatically try to load the records. This seems like the right way to handle an ID with a missing record.