### PR TITLE
fix(resourceModule): let state return a function

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -119,7 +119,7 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
   return {
     namespaced: true,
 
-    state: initialState(),
+    state: initialState,
 
     mutations: {
       REPLACE_ALL_RECORDS: (state, records) => {


### PR DESCRIPTION
This addresses the `'state' should be a method that returns an object` warning I encountered on a nuxt project. The Vuex documentation over at https://vuex.vuejs.org/guide/modules.html#module-local-state does also use a method for the `state` when building the local state of the example module.