### PR TITLE
fix: prevent nullyfing updated record's old relations if no new ones …

### DIFF
--- a/src/reststate-vuex.js
+++ b/src/reststate-vuex.js
@@ -323,7 +323,13 @@ const resourceModule = ({ name: resourceName, httpClient }) => {
           const oldRecord = getters.byId({ id: record.id });
 
           // remove old relationships first
-          if (oldRecord && oldRecord.relationships) {
+          // it only makes sense if we temper with the record's relationships
+          if (
+            oldRecord &&
+            oldRecord.relationships &&
+            record &&
+            record.relationships
+          ) {
             for (const entry of Object.entries(oldRecord.relationships)) {
               const [relationship, entity] = entry;
               const type = getRelationshipType(entity);


### PR DESCRIPTION
This request will prevent the undefined follow-up storeRelated calls on update requests with no relationship data